### PR TITLE
Fix analysis handling and display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# PyInstaller
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+*.cover
+*.py,cover
+.hypothesis/
+
+# Virtual environments
+venv/
+ENV/
+.env/
+
+# MacOS metadata files
+.DS_Store
+

--- a/chess_app/engine/engine_worker.py
+++ b/chess_app/engine/engine_worker.py
@@ -22,8 +22,9 @@ class EngineWorker:
         self.state = EngineState.IDLE
         self.command_queue = queue.Queue()
         self.stop_event = threading.Event()  # Used to signal analysis loop to stop
-        self.analysis_stopped_event = threading.Event() # Used by stop_analysis() to wait for analysis to fully stop
-        self.analysis_info = None # Stores the AnalysisResult object from engine.analysis()
+        self.analysis_stopped_event = threading.Event()  # Used by stop_analysis() to wait for analysis to fully stop
+        self.analysis_info = None  # Stores the AnalysisResult object from engine.analysis()
+        self.latest_analysis_info = None  # Holds the most recent info dict for UI polling
 
         self.worker_thread = threading.Thread(target=self.run, name="EngineWorkerThread", daemon=True)
         self.worker_thread.start()
@@ -95,21 +96,24 @@ class EngineWorker:
         self.state = EngineState.ANALYZING
         self.stop_event.clear()
         self.analysis_stopped_event.clear() # Clear this event as analysis is starting
+        self.latest_analysis_info = None
         logger.info("Starting analysis.")
 
         try:
             # This analysis runs in the worker_thread, blocking other commands until it's stopped.
             with self.engine.analysis(board) as analysis_result:
-                self.analysis_info = analysis_result # Store the result object
-                for info in self.analysis_info: # Iterate over the analysis stream
+                self.analysis_info = analysis_result  # Store the result object
+                for info in self.analysis_info:  # Iterate over the analysis stream
                     if self.stop_event.is_set():
                         logger.info("Stop event received during analysis, terminating.")
                         break
-                    # Process/log analysis info (e.g., send to UI via a callback or queue)
+                    self.latest_analysis_info = info
                     score = info.get('score')
                     pv = info.get('pv')
                     if score is not None and pv is not None:
-                         logger.debug(f"Analysis: Score: {score}, PV: {[str(m) for m in pv]}")
+                        logger.debug(
+                            f"Analysis: Score: {score}, PV: {[str(m) for m in pv]}"
+                        )
         except chess.engine.EngineTerminatedError:
             logger.error("Engine terminated unexpectedly during analysis.", exc_info=True)
             self._handle_engine_failure()
@@ -235,12 +239,15 @@ class EngineWorker:
         # This call assumes that if state is ANALYZING, analysis_stopped_event is currently clear.
         # _handle_start_analysis is responsible for clearing it.
 
-        self.command_queue.put(("STOP_ANALYSIS", ()))
-        logger.info("STOP_ANALYSIS command queued. Waiting for analysis to confirm stoppage.")
+        # Signal the running analysis loop to exit
+        self.stop_event.set()
+        logger.info("Stop event set. Waiting for analysis loop to finish.")
 
         # Wait for the analysis loop's finally block to set this event
-        if not self.analysis_stopped_event.wait(timeout=10.0): # Timeout for safety
-            logger.error("Timeout waiting for analysis to stop. Analysis might still be running or stuck.")
+        if not self.analysis_stopped_event.wait(timeout=10.0):  # Timeout for safety
+            logger.error(
+                "Timeout waiting for analysis to stop. Analysis might still be running or stuck."
+            )
         else:
             logger.info("Analysis confirmed stopped. Engine should be IDLE.")
 
@@ -291,6 +298,10 @@ class EngineWorker:
 
     def get_state(self):
         return self.state
+
+    def get_latest_analysis_info(self):
+        """Return the most recent analysis info dictionary if available."""
+        return self.latest_analysis_info
 
 if __name__ == '__main__':
     # This example assumes you have a UCI chess engine (like Stockfish)

--- a/chess_app/main.py
+++ b/chess_app/main.py
@@ -105,4 +105,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-```

--- a/chess_app/ui/main_window.py
+++ b/chess_app/ui/main_window.py
@@ -199,22 +199,23 @@ class MainWindow(QMainWindow):
         self.update_ui_elements()
 
     # This method would be connected to a signal if EngineWorker streamed analysis
-    def handle_engine_analysis(self, analysis_data: dict):
-        # The current EngineWorker logs analysis but doesn't stream it to UI.
-        # This is a placeholder for how it *could* be handled.
-        # To make this work, EngineWorker's _handle_start_analysis would need to
-        # periodically send `info` dicts (e.g., via a callback that emits self.signals.analysis_update_ready).
-        # For now, this method won't be called directly by the current EngineWorker.
-        # We can simulate displaying last known info if EngineWorker stored it.
-        # Or, could try to parse EngineWorker's logs if desperate (not recommended).
-
-        # Example: score = analysis_data.get('score'), pv = analysis_data.get('pv')
-        # self.analysis_display.setText(f"Score: {score} PV: {pv}")
-        # For now, let's use it to show the current engine state if analyzing
-        if self.engine_worker and self.engine_worker.get_state() == EngineState.ANALYZING:
-            self.analysis_display.setText("Engine is analyzing... (Live data stream not implemented in this version)")
-        else:
+    def handle_engine_analysis(self, analysis_data: dict | None):
+        """Display analysis information from the engine."""
+        if not analysis_data:
             self.analysis_display.clear()
+            return
+
+        score = analysis_data.get("score")
+        pv = analysis_data.get("pv")
+
+        text_parts = []
+        if score is not None:
+            text_parts.append(f"Score: {score}")
+        if pv:
+            pv_str = " ".join(move.uci() for move in pv)
+            text_parts.append(f"PV: {pv_str}")
+
+        self.analysis_display.setText(" | ".join(text_parts))
 
 
     def update_ui_from_engine_state(self):
@@ -235,7 +236,8 @@ class MainWindow(QMainWindow):
             self.analysis_display.clear() # Clear analysis when idle
         elif state == EngineState.ANALYZING:
             self.status_label.setText("Status: Analyzing...")
-            self.handle_engine_analysis({}) # Placeholder call to update analysis display
+            info = self.engine_worker.get_latest_analysis_info()
+            self.handle_engine_analysis(info)
         elif state == EngineState.THINKING:
             # This state is usually brief due to blocking call, status set in request_engine_move_clicked
             self.status_label.setText("Status: Engine is thinking...")
@@ -353,4 +355,3 @@ if __name__ == '__main__':
 #    are handled correctly, especially if EngineWorker becomes more asynchronous with signals.
 #    Direct calls from UI to EngineWorker that block (like current request_best_move) are simpler
 #    but make UI less responsive. Checking state via timer is one way to decouple.
-```


### PR DESCRIPTION
## Summary
- maintain latest analysis info in EngineWorker for UI polling
- stop analysis by setting stop event directly instead of using command queue
- show analysis info in MainWindow
- remove leftover markdown markers

## Testing
- `python -m py_compile chess_app/main.py chess_app/ui/main_window.py chess_app/engine/engine_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff0bd2350832ebb78498e614c6b69