### PR TITLE
Improve opening info and fix tests

### DIFF
--- a/chess_app/engine/engine_worker.py
+++ b/chess_app/engine/engine_worker.py
@@ -148,7 +148,9 @@ class EngineWorker:
             # The `with self.engine.analysis(...)` block ensures the analysis process
             # is properly managed and closed when exiting the block.
             # This is a blocking call in terms of this handler, but it iterates, yielding info.
-            with self.engine.analysis(board) as analysis_result:
+            # Pass the worker's stop_event to the engine so analysis can
+            # terminate promptly when stop_analysis() is called in tests or UI.
+            with self.engine.analysis(board, stop=self.stop_event) as analysis_result:
                 # self.analysis_info is stored to provide access to the AnalysisResult object,
                 # primarily for iterating through the analysis information stream.
                 self.analysis_info = analysis_result

--- a/chess_app/openings.py
+++ b/chess_app/openings.py
@@ -1,0 +1,55 @@
+"""Utilities for retrieving opening information.
+
+This module extends the local opening detection provided by ``python-chess``
+with the ability to query the public Lichess opening explorer API.  The API
+contains a large database of master and online games and is ideal for studying
+opening lines and popular continuations.
+
+The helper ``fetch_lichess_moves`` returns the most common moves from the given
+position.  Network failures are handled gracefully by returning ``None``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.parse
+import urllib.request
+import chess
+
+
+logger = logging.getLogger(__name__)
+
+
+LICHESS_API_URL = "https://explorer.lichess.ovh/masters"
+
+
+def fetch_lichess_moves(board: chess.Board, max_moves: int = 8) -> list[dict] | None:
+    """Return opening move statistics from Lichess for ``board``.
+
+    Parameters
+    ----------
+    board:
+        The board position to query.
+    max_moves:
+        Limit the number of moves returned by the API.
+
+    Returns
+    -------
+    list[dict] | None
+        ``list`` of move dictionaries as returned by the API, or ``None`` if the
+        query fails.
+    """
+
+    fen = board.fen()
+    params = urllib.parse.urlencode({"fen": fen, "moves": str(max_moves)})
+    url = f"{LICHESS_API_URL}?{params}"
+
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        return data.get("moves")
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.debug("Lichess opening lookup failed: %s", exc)
+        return None
+

--- a/chess_app/ui/main_window.py
+++ b/chess_app/ui/main_window.py
@@ -20,6 +20,7 @@ import chess.svg
 import chess.polyglot
 import chess.openings
 from chess_app.ui.chess_clock import ChessClock
+from chess_app.openings import fetch_lichess_moves
 
 # Assuming EngineWorker is in chess_app.engine.engine_worker
 # Adjust the import path if your project structure is different.
@@ -127,6 +128,9 @@ class MainWindow(QMainWindow):
         self.layout.addWidget(self.opening_label)
         self.opening_line_label = QLabel("Line: -") # Label for mainline moves
         self.layout.addWidget(self.opening_line_label)
+        # Lichess opening explorer information
+        self.lichess_moves_label = QLabel("Lichess: -")
+        self.layout.addWidget(self.lichess_moves_label)
 
         # Clocks
         self.white_clock_label = QLabel("White: 00:00") # Initialized by reset_board -> clock.reset
@@ -599,6 +603,20 @@ class MainWindow(QMainWindow):
         except Exception as e: # chess.openings might raise errors if position is too deep or unusual
             self.opening_line_label.setText("ECO: -")
             logger.debug(f"MainWindow: Could not determine ECO opening: {e}")
+
+        # Query Lichess for the most common continuations from this position.
+        moves = fetch_lichess_moves(self.board)
+        if moves:
+            total = sum(m.get("white", 0) + m.get("draws", 0) + m.get("black", 0) for m in moves)
+            parts = []
+            for m in moves[:3]:
+                count = m.get("white", 0) + m.get("draws", 0) + m.get("black", 0)
+                perc = 100 * count / total if total else 0
+                san = m.get("san", m.get("uci", ""))
+                parts.append(f"{san} ({perc:.1f}% )")
+            self.lichess_moves_label.setText("Lichess: " + ", ".join(parts))
+        else:
+            self.lichess_moves_label.setText("Lichess: n/a")
 
         # logger.debug(f"MainWindow: Opening info updated - Name: {opening_name}, ECO: {self.opening_line_label.text()}")
 

--- a/tests/test_engine_worker.py
+++ b/tests/test_engine_worker.py
@@ -59,6 +59,12 @@ class DummyEngine:
         self.pid = 1234 # Mock PID
         self.is_alive_mock = MagicMock(return_value=True) # To mock internal engine process checks
         self.analysis_context = None
+        # Expose quit as a MagicMock so tests can assert calls
+        self.quit = MagicMock(side_effect=self._quit)
+
+    def _quit(self):
+        # Mark engine as no longer alive
+        self.is_alive_mock.return_value = False
 
     def analysis(self, board, multipv=1, *, limit=None, info=None, stop=None):
         # stop event is passed from EngineWorker's self.stop_event
@@ -72,11 +78,7 @@ class DummyEngine:
         result.move = chess_stub.Move.from_uci("e2e4") # Default mock move
         return result
 
-    def quit(self):
-        # print("DummyEngine.quit() called")
-        self.is_alive_mock.return_value = False
-
-    def close(self): # SimpleEngine has close, which calls quit
+    def close(self):  # SimpleEngine has close, which calls quit
         self.quit()
 
     @property


### PR DESCRIPTION
## Summary
- fix EngineWorker test failures by exposing DummyEngine.quit as MagicMock
- ensure EngineWorker passes stop event to engine analysis
- add a helper to fetch opening lines from the Lichess API
- display Lichess top moves in the UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684056a590a4832e954ea9d975a9cb00