### PR TITLE
Add Ubuntu setup script and macOS instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,123 @@
+# Chess App
+
+This is a chess application with a graphical user interface.
+
+## Setup Instructions
+
+### Prerequisites
+
+*   Python 3.x
+*   Git
+
+### Installation
+
+1.  **Download the repository:**
+
+    Open your terminal or command prompt and use the following command to clone the repository to your local machine:
+
+    ```bash
+    git clone https://github.com/your-username/chess-app.git
+    ```
+
+    Replace `https://github.com/your-username/chess-app.git` with the actual URL of this repository.
+
+2.  **Navigate to the project directory:**
+
+    ```bash
+    cd chess-app
+    ```
+
+3.  **Set up a Python virtual environment (recommended):**
+
+    It's highly recommended to use a virtual environment to manage project-specific dependencies. This keeps your global Python installation clean.
+
+    *   **Create a virtual environment (macOS/Linux):**
+        ```bash
+        python3 -m venv venv
+        ```
+    *   **Activate the virtual environment (macOS/Linux):**
+        ```bash
+        source venv/bin/activate
+        ```
+    For Windows, the commands are slightly different. Please refer to the official Python documentation for `venv`.
+
+4.  **Install Python dependencies:**
+
+    The primary known dependency for the graphical interface is PySide6.
+
+    Install it using pip:
+    ```bash
+    pip install PySide6
+    ```
+    Other dependencies might be identified as development progresses. For now, PySide6 is the essential one to get started.
+
+5.  **Configure the Stockfish Chess Engine (macOS):**
+
+    This application uses the Stockfish chess engine for gameplay analysis and opponent moves. You need to have a Stockfish executable accessible to the application. You can download Stockfish from [https://stockfishchess.org/download/](https://stockfishchess.org/download/). Choose the appropriate version for your Mac (e.g., AVX2 or POPCNT).
+
+    There are two primary ways to configure Stockfish:
+
+    *   **Method 1: Using the `STOCKFISH_ENV_PATH` Environment Variable**
+
+        You can tell the application exactly where to find your Stockfish executable by setting this environment variable.
+
+        *   **For the current terminal session:**
+            Open your terminal and run:
+            ```bash
+            export STOCKFISH_ENV_PATH=/path/to/your/stockfish
+            ```
+            **Note:** Replace `/path/to/your/stockfish` with the actual, full path to your Stockfish executable file (e.g., `/Users/yourname/Downloads/stockfish-16-mac-x86-64-avx2/stockfish`).
+
+        *   **To set it permanently (recommended for convenience):**
+            Add the `export` command to your shell's configuration file. If you are using Zsh (default on newer macOS versions), this is `~/.zshrc`. If you are using Bash, it's typically `~/.bash_profile` or `~/.bashrc`.
+            For example, to add it to `~/.zshrc`:
+            ```bash
+            echo 'export STOCKFISH_ENV_PATH=/path/to/your/stockfish' >> ~/.zshrc
+            source ~/.zshrc  # Apply the changes to the current session
+            ```
+            Remember to replace `/path/to/your/stockfish` with the actual path.
+
+    *   **Method 2: Ensuring Stockfish is in the System `PATH`**
+
+        If Stockfish is in a directory that's part of your system's `PATH` environment variable, the application should find it automatically.
+
+        *   **Option A: Copy Stockfish to a standard `PATH` directory:**
+            You can copy the Stockfish executable to a directory like `/usr/local/bin`.
+            ```bash
+            sudo cp /path/to/your/stockfish /usr/local/bin/stockfish
+            ```
+            Again, replace `/path/to/your/stockfish` with the actual path to the executable. You'll need administrator privileges (`sudo`) for this.
+
+        *   **Option B: Add Stockfish's directory to your `PATH`:**
+            If you prefer to keep the Stockfish executable where you downloaded it, you can add its containing directory to your `PATH`.
+            For example, if Stockfish is in `/Users/yourname/Downloads/stockfish-16-mac-x86-64-avx2/`, you would add this directory to your `PATH`.
+            Edit your `~/.zshrc` (or `~/.bash_profile`) and add a line like:
+            ```bash
+            export PATH="/path/to/your/stockfish_directory:$PATH"
+            ```
+            Replace `/path/to/your/stockfish_directory` with the path to the *directory* containing the Stockfish executable. Then, source the file (e.g., `source ~/.zshrc`).
+
+    **Important:** After downloading Stockfish, ensure the executable has permission to run. You might need to use `chmod +x /path/to/your/stockfish`.
+
+## Running the Application
+
+Once you have completed all the setup steps:
+
+1.  **Navigate to the project's root directory** (if you're not already there):
+    ```bash
+    cd path/to/chess-app
+    ```
+    (Replace `path/to/chess-app` with the actual path if you named the directory differently or are not in its parent directory). If you followed the previous steps, you might already be in this directory (`chess-app`).
+
+2.  **Activate your virtual environment** (if you created one):
+    ```bash
+    source venv/bin/activate
+    ```
+    Remember to do this every time you open a new terminal session to work on the project.
+
+3.  **Run the application:**
+    ```bash
+    python chess_app/main.py
+    ```
+
+This should launch the chess application's graphical user interface.

--- a/setup_chess_ubuntu.sh
+++ b/setup_chess_ubuntu.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+set -e
+
+# --- Preamble & Definitions ---
+TARGET_DIR="/home/cosmopax/Desktop/chess_jules"
+APP_REPO_URL="<YOUR_CHESS_APP_REPO_URL_HERE>" # IMPORTANT: Replace this URL!
+APP_DIR_NAME="chess-app"
+STOCKFISH_DOWNLOAD_URL="https://stockfishchess.org/files/stockfish-16.1-linux-x86-64.tar.gz"
+STOCKFISH_INTERNAL_EXEC_NAME="stockfish_binary" # Renamed executable inside our stockfish_engine dir
+
+echo "--- Chess App Setup Script for Ubuntu ---"
+echo "Target directory: $TARGET_DIR"
+echo "App Repository URL: $APP_REPO_URL"
+echo "Stockfish Download URL: $STOCKFISH_DOWNLOAD_URL"
+echo ""
+
+# --- System Dependencies ---
+echo "--- Checking and Installing System Dependencies ---"
+sudo apt update
+sudo apt install -y git python3 python3-venv python3-pip wget tar
+echo "System dependencies checked/installed."
+echo ""
+
+# --- Target Directory ---
+echo "--- Preparing Target Directory ---"
+mkdir -p "$TARGET_DIR"
+cd "$TARGET_DIR"
+echo "Changed directory to $TARGET_DIR"
+echo ""
+
+# --- Chess App Repository (Clone or Update) ---
+echo "--- Setting up Chess Application Repository ---"
+APP_PATH="$TARGET_DIR/$APP_DIR_NAME"
+if [ -d "$APP_PATH" ]; then
+    echo "Application directory '$APP_PATH' already exists. Attempting to update..."
+    cd "$APP_PATH"
+    git pull
+    cd "$TARGET_DIR"
+    echo "Application repository updated."
+else
+    echo "Cloning application repository from '$APP_REPO_URL' into '$APP_DIR_NAME'..."
+    git clone "$APP_REPO_URL" "$APP_DIR_NAME"
+    echo "Application repository cloned."
+fi
+echo ""
+
+# --- Python Virtual Environment & Dependencies ---
+echo "--- Setting up Python Virtual Environment and Dependencies ---"
+cd "$APP_PATH"
+if [ ! -d "venv" ]; then
+    echo "Creating Python virtual environment..."
+    python3 -m venv venv
+    echo "Virtual environment created."
+else
+    echo "Virtual environment 'venv' already exists."
+fi
+
+echo "Installing PySide6 into the virtual environment..."
+venv/bin/pip install PySide6
+echo "PySide6 installation complete."
+cd "$TARGET_DIR"
+echo ""
+
+# --- Stockfish Setup/Update ---
+echo "--- Setting up/Updating Stockfish Chess Engine ---"
+STOCKFISH_DIR="$TARGET_DIR/stockfish_engine"
+mkdir -p "$STOCKFISH_DIR"
+cd "$STOCKFISH_DIR"
+
+echo "Removing old Stockfish version if any..."
+rm -rf ./* # Clear out the directory before downloading new version
+
+echo "Downloading Stockfish from $STOCKFISH_DOWNLOAD_URL..."
+if wget -O stockfish_archive.tar.gz "$STOCKFISH_DOWNLOAD_URL"; then
+    echo "Stockfish archive downloaded."
+    echo "Extracting Stockfish..."
+    # Attempt to extract, stripping the top-level directory if present
+    # The find command below will look for the actual binary
+    if tar -xvzf stockfish_archive.tar.gz --strip-components=1; then
+        echo "Stockfish extracted."
+
+        # Search for the main Stockfish executable.
+        # Prioritize common names. Exclude text/doc files.
+        FOUND_EXEC=$(find . -maxdepth 1 -type f \( -name "stockfish" -o -name "stockfish-*" -o -name "Stockfish" \) ! -name "*.md" ! -name "*.txt" ! -name "*.tar.gz" -print -quit)
+
+        if [ -n "$FOUND_EXEC" ] && [ -f "$FOUND_EXEC" ]; then
+            echo "Found Stockfish executable: $FOUND_EXEC"
+            mv "$FOUND_EXEC" "$STOCKFISH_INTERNAL_EXEC_NAME"
+            chmod +x "$STOCKFISH_INTERNAL_EXEC_NAME"
+            echo "Stockfish setup complete. Executable: $STOCKFISH_DIR/$STOCKFISH_INTERNAL_EXEC_NAME"
+        else
+            echo "Error: Could not find the Stockfish executable after extraction."
+            echo "Please check the archive structure at $STOCKFISH_DOWNLOAD_URL or the extraction process."
+            echo "The downloaded archive stockfish_archive.tar.gz is still in $STOCKFISH_DIR for inspection."
+        fi
+    else
+        echo "Error: Failed to extract Stockfish archive. The archive might be corrupted or the structure unexpected."
+        echo "The downloaded archive stockfish_archive.tar.gz is still in $STOCKFISH_DIR for inspection."
+    fi
+else
+    echo "Error: wget failed to download Stockfish from $STOCKFISH_DOWNLOAD_URL."
+    echo "Skipping further Stockfish processing for this run."
+fi
+cd "$TARGET_DIR"
+echo ""
+
+# --- Create Launcher Script (run_chess.sh) ---
+echo "--- Creating Launcher Script (run_chess.sh) ---"
+LAUNCHER_SCRIPT_PATH="$TARGET_DIR/run_chess.sh"
+
+# Using a heredoc for the launcher script content
+cat > "$LAUNCHER_SCRIPT_PATH" << EOL
+#!/bin/bash
+# Launcher for the Chess App
+set -e
+
+echo "Changing directory to script location: \$(dirname "\$0")"
+cd "\$(dirname "\$0")" # Ensures script runs reliably from any location
+
+TARGET_DIR_BASE="\$PWD" # Should be $TARGET_DIR
+APP_DIR_NAME_LAUNCHER="$APP_DIR_NAME" # Must match APP_DIR_NAME from setup
+APP_PATH_LAUNCHER="\$TARGET_DIR_BASE/\$APP_DIR_NAME_LAUNCHER"
+STOCKFISH_INTERNAL_EXEC_NAME_LAUNCHER="$STOCKFISH_INTERNAL_EXEC_NAME" # Must match from setup
+STOCKFISH_EXEC_PATH_LAUNCHER="\$TARGET_DIR_BASE/stockfish_engine/\$STOCKFISH_INTERNAL_EXEC_NAME_LAUNCHER"
+
+echo "Activating Python virtual environment from \$APP_PATH_LAUNCHER/venv..."
+if [ -f "\$APP_PATH_LAUNCHER/venv/bin/activate" ]; then
+    source "\$APP_PATH_LAUNCHER/venv/bin/activate"
+else
+    echo "Error: Virtual environment not found at \$APP_PATH_LAUNCHER/venv."
+    echo "Please run the setup script (setup_chess_ubuntu.sh) again."
+    exit 1
+fi
+
+echo "Setting STOCKFISH_ENV_PATH to \$STOCKFISH_EXEC_PATH_LAUNCHER"
+export STOCKFISH_ENV_PATH="\$STOCKFISH_EXEC_PATH_LAUNCHER"
+
+echo "Launching Chess App from \$APP_PATH_LAUNCHER/chess_app/main.py..."
+if [ -f "\$APP_PATH_LAUNCHER/chess_app/main.py" ]; then
+    python "\$APP_PATH_LAUNCHER/chess_app/main.py"
+else
+    echo "Error: Main application script not found at \$APP_PATH_LAUNCHER/chess_app/main.py."
+    echo "Please check the repository structure or run the setup script again."
+    exit 1
+fi
+
+# Deactivation is tricky with GUI apps.
+# If the python app exits cleanly, this might run.
+# If user closes GUI window, the script waiting on 'python' might exit immediately.
+# echo "Chess app exited. Deactivating virtual environment (if still active in this script's context)..."
+# if type deactivate > /dev/null 2>&1; then
+#    deactivate
+# fi
+EOL
+
+chmod +x "$LAUNCHER_SCRIPT_PATH"
+echo "Launcher script created at $LAUNCHER_SCRIPT_PATH"
+echo ""
+
+# --- Final Instructions ---
+echo "--- Setup Script Finished ---"
+echo "IMPORTANT: You MUST replace '<YOUR_CHESS_APP_REPO_URL_HERE>' in this script"
+echo "           (setup_chess_ubuntu.sh) with the actual Git repository URL for the chess application."
+echo "           Currently set to: $APP_REPO_URL"
+echo ""
+echo "To make this setup script executable (if you haven't already):"
+echo "  chmod +x setup_chess_ubuntu.sh"
+echo ""
+echo "To run the application after successful setup:"
+echo "  cd \"$TARGET_DIR\" && ./run_chess.sh"
+echo ""
+echo "To update the application and Stockfish in the future, simply re-run this setup script:"
+echo "  ./setup_chess_ubuntu.sh  (if you are in $TARGET_DIR)"
+echo "  OR"
+echo "  /path/to/setup_chess_ubuntu.sh (if run from elsewhere)"
+echo ""
+echo "If Stockfish download or extraction fails, check the URL or the archive structure."
+echo "The downloaded archive 'stockfish_archive.tar.gz' will be in '$STOCKFISH_DIR' for inspection in case of tar errors."
+echo "--- End of Script ---"


### PR DESCRIPTION
This commit introduces:
1. `setup_chess_ubuntu.sh`: An automated script for setting up the chess application on Ubuntu. It handles cloning the repository, Python environment setup (venv with PySide6), downloading and configuring the Stockfish engine, and creating a launcher script. The target directory for the functional application is `/home/cosmopax/Desktop/chess_jules`. The script is designed to be re-run for updates.

2. Updated `README.md`: Includes comprehensive instructions for downloading, setting up, and running the application on macOS, covering Python dependencies and Stockfish configuration.

These additions make it easier for you to get started with the application on both macOS and Ubuntu.