### PR TITLE
Improve setup and add FEN import

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,29 @@ This is a chess application with a graphical user interface.
 
 4.  **Install Python dependencies:**
 
-    The primary known dependency for the graphical interface is PySide6.
+The primary known dependency for the graphical interface is PySide6.
 
     Install it using pip:
     ```bash
     pip install PySide6
     ```
     Other dependencies might be identified as development progresses. For now, PySide6 is the essential one to get started.
+
+### Quick Setup Scripts
+
+For convenience the repository includes shell scripts that download the app and the Stockfish engine in one step.
+
+* **Ubuntu/Linux:** `setup_chess_ubuntu.sh`
+* **macOS:** `setup_chess_macos.sh`
+
+Both scripts clone this repository, create a Python virtual environment, download a Stockfish binary and generate a `run_chess.sh` launcher. Edit the `APP_REPO_URL` variable inside the script to point to your fork or mirror, make the script executable and run it:
+
+```bash
+chmod +x setup_chess_ubuntu.sh
+./setup_chess_ubuntu.sh
+```
+
+After the script finishes you can start the GUI with `./run_chess.sh` from the target directory.
 
 5.  **Configure the Stockfish Chess Engine (macOS):**
 

--- a/chess_app/engine/engine_worker.py
+++ b/chess_app/engine/engine_worker.py
@@ -142,6 +142,12 @@ class EngineWorker:
         self.stop_event.clear()             # Clear the stop signal for the new analysis session.
         self.analysis_stopped_event.clear() # Clear this event; it will be set when analysis truly stops.
         self.latest_analysis_info = None    # Reset previous analysis data.
+
+        # Ensure the engine knows whether we're analysing a Chess960 position or not
+        try:
+            self.engine.configure({"UCI_Chess960": board.chess960})
+        except Exception as e:
+            logger.warning(f"Engine _handle_start_analysis: Failed to configure UCI_Chess960 option: {e}")
         logger.info("Engine _handle_start_analysis: Starting continuous analysis.")
 
         try:
@@ -214,6 +220,10 @@ class EngineWorker:
             return
 
         logger.info(f"Engine _handle_find_best_move: Changing state to THINKING for board: {board.fen()} with time limit: {time_limit}s.")
+        try:
+            self.engine.configure({"UCI_Chess960": board.chess960})
+        except Exception as e:
+            logger.warning(f"Engine _handle_find_best_move: Failed to configure UCI_Chess960 option: {e}")
         self.state = EngineState.THINKING
         best_move = None
         try:

--- a/chess_app/ui/main_window.py
+++ b/chess_app/ui/main_window.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QAction,
     QMessageBox,
     QInputDialog,
+    QFileDialog,
 )
 from PySide6.QtCore import Qt, QTimer, Signal, Slot, QObject
 import random
@@ -177,6 +178,14 @@ class MainWindow(QMainWindow):
         new_960_select_action.triggered.connect(self.new_chess960_select)
         file_menu.addAction(new_960_select_action)
 
+        start_fen_action = QAction("Start From FEN...", self)
+        start_fen_action.triggered.connect(self.new_from_fen)
+        file_menu.addAction(start_fen_action)
+
+        load_fen_file_action = QAction("Load FEN From File...", self)
+        load_fen_file_action.triggered.connect(self.load_fen_from_file)
+        file_menu.addAction(load_fen_file_action)
+
         file_menu.addSeparator()
 
         exit_action = QAction("&Exit", self)
@@ -241,6 +250,42 @@ class MainWindow(QMainWindow):
         self.is_engine_thinking_ui_flag = False # Reset UI thinking flag
         self.update_ui_from_engine_state() # Refresh UI elements based on new state (should be IDLE)
         logger.info("MainWindow: Board reset complete.")
+
+    def load_fen(self, fen: str):
+        """Load a board from a FEN string."""
+        try:
+            new_board = chess.Board(fen)
+        except Exception as e:
+            QMessageBox.warning(self, "Invalid FEN", f"Could not load FEN:\n{e}")
+            return
+
+        if self.engine_worker and self.engine_worker.get_state() == EngineState.ANALYZING:
+            self.engine_worker.stop_analysis()
+
+        self.board = new_board
+        self.clock.reset()
+        self.clock.start(self.board.turn)
+        self.update_board_display()
+        self.analysis_display.clear()
+        self.status_label.setText("Status: Position loaded.")
+        self.update_ui_from_engine_state()
+
+    def new_from_fen(self):
+        """Prompt the user for a FEN string and start a game from that position."""
+        fen, ok = QInputDialog.getText(self, "Start From FEN", "Enter FEN string:")
+        if ok and fen:
+            self.load_fen(fen)
+
+    def load_fen_from_file(self):
+        """Load a FEN string from a file."""
+        path, _ = QFileDialog.getOpenFileName(self, "Open FEN File", "", "FEN Files (*.fen);;All Files (*)")
+        if path:
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    line = f.readline().strip()
+                self.load_fen(line)
+            except Exception as e:
+                QMessageBox.warning(self, "File Error", f"Could not read FEN file:\n{e}")
 
 
     def toggle_analysis_clicked(self):

--- a/setup_chess_macos.sh
+++ b/setup_chess_macos.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+TARGET_DIR="$HOME/chess_app"
+APP_REPO_URL="<YOUR_CHESS_APP_REPO_URL_HERE>"
+APP_DIR_NAME="chess-app"
+STOCKFISH_URL="https://stockfishchess.org/files/stockfish-16-macOS.zip"
+STOCKFISH_INTERNAL_EXEC_NAME="stockfish_binary"
+
+echo "--- Chess App Setup Script for macOS ---"
+mkdir -p "$TARGET_DIR"
+cd "$TARGET_DIR"
+
+# Install dependencies via Homebrew if available
+if command -v brew >/dev/null 2>&1; then
+    brew install git python3 wget unzip >/dev/null
+fi
+
+if [ -d "$APP_DIR_NAME" ]; then
+    cd "$APP_DIR_NAME" && git pull && cd ..
+else
+    git clone "$APP_REPO_URL" "$APP_DIR_NAME"
+fi
+
+cd "$APP_DIR_NAME"
+python3 -m venv venv
+venv/bin/pip install PySide6
+cd ..
+
+mkdir -p stockfish_engine
+cd stockfish_engine
+wget -O sf.zip "$STOCKFISH_URL"
+unzip -o sf.zip
+FOUND_EXEC=$(find . -name "stockfish*" -perm +111 -type f | head -n 1)
+if [ -n "$FOUND_EXEC" ]; then
+    mv "$FOUND_EXEC" "$STOCKFISH_INTERNAL_EXEC_NAME"
+    chmod +x "$STOCKFISH_INTERNAL_EXEC_NAME"
+fi
+cd ..
+
+cat > run_chess.sh <<EOL
+#!/bin/bash
+cd "$(dirname "$0")"
+source "$APP_DIR_NAME/venv/bin/activate"
+export STOCKFISH_ENV_PATH="$(pwd)/stockfish_engine/$STOCKFISH_INTERNAL_EXEC_NAME"
+python "$APP_DIR_NAME/chess_app/main.py"
+EOL
+chmod +x run_chess.sh
+
+echo "Setup finished. Run ./run_chess.sh to start the application."
+

--- a/tests/test_engine_worker.py
+++ b/tests/test_engine_worker.py
@@ -9,8 +9,11 @@ from unittest.mock import patch, MagicMock, PropertyMock
 chess_stub = types.ModuleType('chess')
 
 class DummyBoard:
+    def __init__(self, fen="dummy_fen", chess960=False):
+        self._fen = fen
+        self.chess960 = chess960
     def fen(self):
-        return "dummy_fen"
+        return self._fen
     def copy(self):
         return self
     def is_game_over(self):
@@ -59,6 +62,7 @@ class DummyEngine:
         self.pid = 1234 # Mock PID
         self.is_alive_mock = MagicMock(return_value=True) # To mock internal engine process checks
         self.analysis_context = None
+        self.configure_calls = []
         # Expose quit as a MagicMock so tests can assert calls
         self.quit = MagicMock(side_effect=self._quit)
 
@@ -77,6 +81,9 @@ class DummyEngine:
         result = MagicMock()
         result.move = chess_stub.Move.from_uci("e2e4") # Default mock move
         return result
+
+    def configure(self, options):
+        self.configure_calls.append(options)
 
     def close(self):  # SimpleEngine has close, which calls quit
         self.quit()
@@ -225,6 +232,24 @@ class TestEngineWorker(unittest.TestCase):
         # request_best_move is blocking and should return the state to IDLE itself.
         self.assertEqual(worker.get_state(), EngineState.IDLE, "Engine should return to IDLE after finding move.")
         mock_engine_instance.play.assert_called_once()
+
+        worker.quit_engine()
+        self.wait_for_engine_state(worker, EngineState.SHUTDOWN)
+
+    @patch('chess.engine.SimpleEngine.popen_uci')
+    def test_chess960_option_set(self, mock_popen_uci):
+        mock_engine_instance = DummyEngine("test_960")
+        mock_popen_uci.return_value = mock_engine_instance
+
+        worker = EngineWorker(engine_path='dummy_path')
+        self.wait_for_engine_init(worker)
+
+        board960 = DummyBoard(chess960=True)
+        worker.start_analysis(board960)
+        self.wait_for_engine_state(worker, EngineState.ANALYZING, timeout=0.5)
+        worker.stop_analysis()
+
+        self.assertIn({'UCI_Chess960': True}, mock_engine_instance.configure_calls)
 
         worker.quit_engine()
         self.wait_for_engine_state(worker, EngineState.SHUTDOWN)


### PR DESCRIPTION
## Summary
- add macOS setup script that bundles Stockfish
- enable Stockfish Chess960 mode when needed
- allow starting games from a FEN string or FEN file
- document quick setup scripts in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468a432dac832e8bd53b597bfb1204