### PR TITLE
Integrate Gemma3n LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ chmod +x setup_chess_ubuntu.sh
 
 After the script finishes you can start the GUI with `./run_chess.sh` from the target directory.
 
+### Optional Gemma 3n Model
+
+The setup scripts can optionally download Google's Gemma 3n language model. If selected during installation the model files are placed inside the setup environment and the application exposes a **Chat with Gemma 3n** menu option. The model download is large, so decline the prompt if you only want the chess GUI.
+
 5.  **Configure the Stockfish Chess Engine (macOS):**
 
     This application uses the Stockfish chess engine for gameplay analysis and opponent moves. You need to have a Stockfish executable accessible to the application. You can download Stockfish from [https://stockfishchess.org/download/](https://stockfishchess.org/download/). Choose the appropriate version for your Mac (e.g., AVX2 or POPCNT).
@@ -92,6 +96,13 @@ After the script finishes you can start the GUI with `./run_chess.sh` from the t
             source ~/.zshrc  # Apply the changes to the current session
             ```
             Remember to replace `/path/to/your/stockfish` with the actual path.
+
+    *   **Gemma 3n model**
+
+        If you installed Gemma during setup, the launcher script automatically sets
+        the environment variables `GEMMA3N_MODEL_PATH` and `GEMMA3N_VOCAB_PATH`.
+        If you downloaded the model manually, set these variables yourself so the
+        "Chat with Gemma 3n" feature can locate the files.
 
     *   **Method 2: Ensuring Stockfish is in the System `PATH`**
 

--- a/chess_app/gemma_integration.py
+++ b/chess_app/gemma_integration.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+import sys
+
+SCRIPT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'run_gemma3n.py'))
+
+MODEL_PATH = os.environ.get('GEMMA3N_MODEL_PATH')
+VOCAB_PATH = os.environ.get('GEMMA3N_VOCAB_PATH')
+
+def gemma_chat(prompt: str) -> str:
+    """Run Gemma 3n on the given prompt and return stdout."""
+    if not MODEL_PATH or not VOCAB_PATH:
+        raise FileNotFoundError('Gemma model environment variables not set.')
+    cmd = [sys.executable, SCRIPT_PATH, '--model', MODEL_PATH, '--vocab', VOCAB_PATH, '-p', prompt]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f'Gemma invocation failed: {proc.stderr}')
+    return proc.stdout

--- a/chess_app/ui/main_window.py
+++ b/chess_app/ui/main_window.py
@@ -247,12 +247,41 @@ class MainWindow(QMainWindow):
         tools_menu = self.menubar.addMenu("&Tools")
         explore_openings_action = QAction("Explore Openings...", self); explore_openings_action.triggered.connect(self.show_opening_explorer)
         tools_menu.addAction(explore_openings_action)
+        gemma_chat_action = QAction("Chat with Gemma 3n...", self)
+        gemma_chat_action.triggered.connect(self.open_gemma_chat)
+        tools_menu.addAction(gemma_chat_action)
         logger.debug("Menu bar created.")
 
     def show_opening_explorer(self):
         dialog = OpeningExplorerDialog(self)
         dialog.opening_selected_for_practice.connect(self.handle_setup_opening_for_practice)
         dialog.exec()
+
+    def open_gemma_chat(self):
+        """Open a dialog to query Gemma 3n about the current game."""
+        if not os.getenv('GEMMA3N_MODEL_PATH'):
+            QMessageBox.warning(self, "Gemma 3n", "Gemma model not configured. Set GEMMA3N_MODEL_PATH environment variable.")
+            return
+        user_text, ok = QInputDialog.getMultiLineText(self, "Chat with Gemma 3n", "Enter your question:")
+        if not ok or not user_text.strip():
+            return
+        moves = " ".join(m.uci() for m in self.board.move_stack)
+        best_move = None
+        if self.engine_worker and self.engine_worker.get_state() == EngineState.IDLE:
+            try:
+                mv = self.engine_worker.request_best_move(self.board.copy(), 0.1)
+                if mv:
+                    best_move = mv.uci()
+            except Exception:
+                pass
+        prompt = f"{user_text}\nMoves so far: {moves}\nEngine best move: {best_move if best_move else 'N/A'}"
+        try:
+            from chess_app.gemma_integration import gemma_chat
+            response = gemma_chat(prompt)
+        except Exception as exc:
+            QMessageBox.critical(self, "Gemma 3n Error", str(exc))
+            return
+        QMessageBox.information(self, "Gemma 3n", response)
 
     def new_standard_game_as_color(self, player_chosen_color: bool):
         """Starts a new standard game with the player as the chosen color."""

--- a/run_gemma3n.py
+++ b/run_gemma3n.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import argparse
+import numpy as np
+import tensorflow as tf
+from PIL import Image
+import sentencepiece as spm
+import os
+
+# === DEFAULTS (will be overridden by CLI or env vars) ===
+DEFAULT_MODEL = os.environ.get("GEMMA3N_MODEL_PATH", "path/to/model.tflite")
+DEFAULT_VOCAB = os.environ.get("GEMMA3N_VOCAB_PATH", "path/to/vocab.model")
+# ============================================
+
+def load_images(shapes, image_paths):
+    """Return list of [1,H,W,C] float32 arrays normalized to [0,1]."""
+    arrays = []
+    for path in image_paths:
+        img = Image.open(path).convert("RGB")
+        img = img.resize((shapes[0][2], shapes[0][1]), Image.BILINEAR)
+        arr = np.asarray(img, dtype=np.float32) / 255.0
+        arrays.append(np.expand_dims(arr, axis=0))
+    return arrays
+
+def load_prompts(shapes, prompts, vocab_file):
+    """Return list of [1,seq_len] int32 arrays via SentencePiece."""
+    sp = spm.SentencePieceProcessor(model_file=vocab_file)
+    arrays = []
+    for text in prompts:
+        ids = sp.encode(text, out_type=int)
+        seq_len = shapes[1][1]
+        ids = ids[:seq_len] + [0] * (max(0, seq_len - len(ids)))
+        arrays.append(np.array([ids], dtype=np.int32))
+    return arrays
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run Gemma 3n TFLite inference on images and/or text"
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Path to .tflite model file")
+    parser.add_argument("--vocab", default=DEFAULT_VOCAB, help="SentencePiece model file from metadata")
+    parser.add_argument("--images", "-i", nargs="*", default=[], help="Paths to input images")
+    parser.add_argument("--prompts", "-p", nargs="*", default=[], help="Text prompts to run")
+    args = parser.parse_args()
+
+    interpreter = tf.lite.Interpreter(model_path=args.model)
+    interpreter.allocate_tensors()
+
+    idet = interpreter.get_input_details()
+    odet = interpreter.get_output_details()
+    print("Input tensors:", idet)
+    print("Output tensors:", odet)
+
+    image_inputs = load_images(idet, args.images)
+    prompt_inputs = load_prompts(idet, args.prompts, args.vocab)
+
+    for inp in image_inputs:
+        interpreter.set_tensor(idet[0]["index"], inp)
+        interpreter.invoke()
+        out = interpreter.get_tensor(odet[0]["index"])
+        print(f"Image output for shape {inp.shape}:", out)
+
+    for inp in prompt_inputs:
+        interpreter.set_tensor(idet[0]["index"], inp)
+        interpreter.invoke()
+        out = interpreter.get_tensor(odet[0]["index"])
+        print(f"Prompt output for shape {inp.shape}:", out)
+
+if __name__ == "__main__":
+    main()

--- a/setup_chess_macos.sh
+++ b/setup_chess_macos.sh
@@ -11,6 +11,9 @@ STOCKFISH_DOWNLOAD_URL="https://stockfishchess.org/files/stockfish-macos-x86-64-
 STOCKFISH_DIR_NAME="stockfish_engine"
 STOCKFISH_INTERNAL_EXEC_NAME="stockfish_binary" # Standardized name for the exec within our env
 VENV_DIR_NAME="venv" # Name of the virtual environment directory
+GEMMA_DIR_NAME="gemma3n"
+GEMMA_MODEL_URL="https://storage.googleapis.com/gemma-models/gemma-3n.tflite"
+GEMMA_VOCAB_URL="https://storage.googleapis.com/gemma-models/gemma-3n.vocab"
 
 echo "Application Source Directory: $APP_SOURCE_DIR"
 echo "Environment Target Directory for Stockfish: $TARGET_DIR"
@@ -89,6 +92,19 @@ echo "Activating virtual environment and installing PySide6..."
 )
 echo "Python dependencies (PySide6) installed in the virtual environment."
 echo ""
+
+# --- Optional Gemma 3n Setup ---
+read -r -p "Download and install Gemma 3n model (~large download)? (y/N): " INSTALL_GEMMA
+if [[ "$INSTALL_GEMMA" =~ ^[Yy]$ ]]; then
+    echo "--- Setting up Gemma 3n ---"
+    GEMMA_PATH="$TARGET_DIR/$GEMMA_DIR_NAME"
+    mkdir -p "$GEMMA_PATH"
+    cd "$GEMMA_PATH"
+    echo "Downloading Gemma model..."
+    wget -O gemma-3n.tflite "$GEMMA_MODEL_URL" && \
+    wget -O gemma-3n.vocab "$GEMMA_VOCAB_URL" && echo "Gemma downloaded." || echo "Gemma download failed."
+    cd "$APP_SOURCE_DIR"
+fi
 
 # --- Stockfish Setup ---
 echo "--- Setting up Stockfish Chess Engine ---"
@@ -187,6 +203,13 @@ fi
 # Export for the application to use
 export STOCKFISH_ENV_PATH="\$STOCKFISH_EXEC_PATH"
 echo "STOCKFISH_ENV_PATH set to: \$STOCKFISH_ENV_PATH"
+
+GEMMA_PATH="\$TARGET_DIR_ENV/$GEMMA_DIR_NAME"
+if [ -f "\$GEMMA_PATH/gemma-3n.tflite" ]; then
+    export GEMMA3N_MODEL_PATH="\$GEMMA_PATH/gemma-3n.tflite"
+    export GEMMA3N_VOCAB_PATH="\$GEMMA_PATH/gemma-3n.vocab"
+    echo "Gemma 3n configured at \$GEMMA_PATH"
+fi
 
 APP_MAIN_SCRIPT="\$APP_SOURCE_DIR/chess_app/main.py"
 if [ ! -f "\$APP_MAIN_SCRIPT" ]; then

--- a/setup_chess_ubuntu.sh
+++ b/setup_chess_ubuntu.sh
@@ -11,6 +11,9 @@ STOCKFISH_DIR_NAME="stockfish_engine"
 STOCKFISH_INTERNAL_EXEC_NAME="stockfish_binary" # Standardized name for the exec within our env
 STOCKFISH_DOWNLOAD_URL="https://stockfishchess.org/files/stockfish-16.1-linux-x86-64.tar.gz"
 VENV_DIR_NAME="venv" # Name of the virtual environment directory
+GEMMA_DIR_NAME="gemma3n"
+GEMMA_MODEL_URL="https://storage.googleapis.com/gemma-models/gemma-3n.tflite"
+GEMMA_VOCAB_URL="https://storage.googleapis.com/gemma-models/gemma-3n.vocab"
 
 echo "Application Source Directory: $APP_SOURCE_DIR"
 echo "Environment Target Directory (for Stockfish): $TARGET_DIR_ENV"
@@ -40,6 +43,19 @@ echo "Activating virtual environment and installing PySide6..."
 )
 echo "Python dependencies (PySide6) installed in $APP_SOURCE_DIR/$VENV_DIR_NAME."
 echo ""
+
+# --- Optional Gemma 3n Setup ---
+read -r -p "Download and install Gemma 3n model (~large download)? (y/N): " INSTALL_GEMMA
+if [[ "$INSTALL_GEMMA" =~ ^[Yy]$ ]]; then
+    echo "--- Setting up Gemma 3n ---"
+    GEMMA_PATH="$TARGET_DIR_ENV/$GEMMA_DIR_NAME"
+    mkdir -p "$GEMMA_PATH"
+    cd "$GEMMA_PATH"
+    echo "Downloading Gemma model..."
+    wget -O gemma-3n.tflite "$GEMMA_MODEL_URL" && \
+    wget -O gemma-3n.vocab "$GEMMA_VOCAB_URL" && echo "Gemma downloaded." || echo "Gemma download failed."
+    cd "$APP_SOURCE_DIR"
+fi
 
 # --- Stockfish Setup ---
 echo "--- Setting up Stockfish Chess Engine in $TARGET_DIR_ENV ---"
@@ -154,6 +170,13 @@ fi
 # Export for the application to use
 export STOCKFISH_ENV_PATH="\$STOCKFISH_EXEC_PATH"
 echo "STOCKFISH_ENV_PATH set to: \$STOCKFISH_ENV_PATH"
+
+GEMMA_PATH="\$TARGET_DIR_ENV_LAUNCHER/$GEMMA_DIR_NAME"
+if [ -f "\$GEMMA_PATH/gemma-3n.tflite" ]; then
+    export GEMMA3N_MODEL_PATH="\$GEMMA_PATH/gemma-3n.tflite"
+    export GEMMA3N_VOCAB_PATH="\$GEMMA_PATH/gemma-3n.vocab"
+    echo "Gemma 3n configured at \$GEMMA_PATH"
+fi
 
 APP_MAIN_SCRIPT="\$APP_SOURCE_DIR/chess_app/main.py"
 if [ ! -f "\$APP_MAIN_SCRIPT" ]; then


### PR DESCRIPTION
## Summary
- add optional Gemma 3n language model install in setup scripts
- document the optional model and environment variables
- provide Gemma invocation helper and script
- expose a "Chat with Gemma 3n" option in the GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b13082a0832eab62edc20a8b54ba