### PR TITLE
Add one-click install with dynamic Stockfish

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The installer detects your operating system, clones this repository and runs the
 * **Ubuntu/Linux:** `setup_chess_ubuntu.sh`
 * **macOS:** `setup_chess_macos.sh`
 
-Both scripts clone this repository, create a Python virtual environment and automatically download the newest Stockfish engine before generating a `run_chess.sh` launcher. Edit the `APP_REPO_URL` variable inside the script to point to your fork or mirror, make the script executable and run it:
+Both scripts clone this repository, create a Python virtual environment and automatically download the newest Stockfish engine before generating a `run_chess.sh` launcher. If you want to use your own fork, either pass the repository URL when running `install_chess_app.sh` or edit the `DEFAULT_REPO_URL` variable inside that script. Then make the setup script executable and run it:
 
 ```bash
 chmod +x setup_chess_ubuntu.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This is a chess application with a graphical user interface.
 
+For a quick installation on macOS or Ubuntu run:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/your-username/chess-app/main/install_chess_app.sh)
+```
+
 ## Setup Instructions
 
 ### Prerequisites
@@ -53,12 +59,18 @@ The primary known dependency for the graphical interface is PySide6.
 
 ### Quick Setup Scripts
 
-For convenience the repository includes shell scripts that download the app and the Stockfish engine in one step.
+For convenience the repository includes shell scripts that download the app and the Stockfish engine in one step. The easiest method is to run the installer directly from GitHub:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/your-username/chess-app/main/install_chess_app.sh)
+```
+
+The installer detects your operating system, clones this repository and runs the appropriate setup script.
 
 * **Ubuntu/Linux:** `setup_chess_ubuntu.sh`
 * **macOS:** `setup_chess_macos.sh`
 
-Both scripts clone this repository, create a Python virtual environment, download a Stockfish binary and generate a `run_chess.sh` launcher. Edit the `APP_REPO_URL` variable inside the script to point to your fork or mirror, make the script executable and run it:
+Both scripts clone this repository, create a Python virtual environment and automatically download the newest Stockfish engine before generating a `run_chess.sh` launcher. Edit the `APP_REPO_URL` variable inside the script to point to your fork or mirror, make the script executable and run it:
 
 ```bash
 chmod +x setup_chess_ubuntu.sh

--- a/install_chess_app.sh
+++ b/install_chess_app.sh
@@ -3,6 +3,7 @@ set -e # Exit immediately if a command exits with a non-zero status.
 
 echo "--- Universal Chess App Installer ---"
 echo "This script will help you download and set up the Chess Application."
+echo "It automatically fetches the newest Stockfish engine and configures the app."
 echo ""
 
 # --- Configuration ---

--- a/setup_chess_macos.sh
+++ b/setup_chess_macos.sh
@@ -7,7 +7,23 @@ echo "--- Chess App Setup Script for macOS ---"
 TARGET_DIR="$HOME/chess_app_env" # Renamed to avoid conflict if app is also named chess_app
 APP_SOURCE_DIR="$(pwd)" # Assumes script is run from the root of the chess app repo
 # APP_NAME_FROM_SOURCE_DIR="\$(basename "\$APP_SOURCE_DIR")" # Not used, but kept for reference
-STOCKFISH_DOWNLOAD_URL="https://stockfishchess.org/files/stockfish-macos-x86-64-modern.zip" # Direct link
+# Determine the latest Stockfish release URL automatically from GitHub
+get_latest_stockfish_url() {
+    python3 - "$1" <<'PY'
+import json, sys, urllib.request
+os_label = sys.argv[1]
+with urllib.request.urlopen("https://api.github.com/repos/official-stockfish/Stockfish/releases/latest") as resp:
+    data = json.load(resp)
+for asset in data.get("assets", []):
+    name = asset.get("name", "").lower()
+    url = asset.get("browser_download_url")
+    if os_label == "macos" and "mac" in name and "x86" in name and name.endswith(".zip"):
+        print(url)
+        break
+PY
+}
+
+STOCKFISH_DOWNLOAD_URL="$(get_latest_stockfish_url macos)"
 STOCKFISH_DIR_NAME="stockfish_engine"
 STOCKFISH_INTERNAL_EXEC_NAME="stockfish_binary" # Standardized name for the exec within our env
 VENV_DIR_NAME="venv" # Name of the virtual environment directory

--- a/setup_chess_ubuntu.sh
+++ b/setup_chess_ubuntu.sh
@@ -9,7 +9,23 @@ APP_SOURCE_DIR="$(pwd)" # Assumes script is run from the root of the chess app r
 # APP_NAME_FROM_SOURCE_DIR="\$(basename "\$APP_SOURCE_DIR")" # Not used, but kept for reference
 STOCKFISH_DIR_NAME="stockfish_engine"
 STOCKFISH_INTERNAL_EXEC_NAME="stockfish_binary" # Standardized name for the exec within our env
-STOCKFISH_DOWNLOAD_URL="https://stockfishchess.org/files/stockfish-16.1-linux-x86-64.tar.gz"
+# Resolve the latest Stockfish release URL dynamically using the GitHub API.
+get_latest_stockfish_url() {
+    python3 - "$1" <<'PY'
+import json, sys, urllib.request
+os_label = sys.argv[1]
+with urllib.request.urlopen("https://api.github.com/repos/official-stockfish/Stockfish/releases/latest") as resp:
+    data = json.load(resp)
+for asset in data.get("assets", []):
+    name = asset.get("name", "").lower()
+    url = asset.get("browser_download_url")
+    if os_label == "linux" and "linux" in name and "x86" in name and (name.endswith(".tar.gz") or name.endswith(".zip") or name.endswith(".tar.zst")):
+        print(url)
+        break
+PY
+}
+
+STOCKFISH_DOWNLOAD_URL="$(get_latest_stockfish_url linux)"
 VENV_DIR_NAME="venv" # Name of the virtual environment directory
 GEMMA_DIR_NAME="gemma3n"
 GEMMA_MODEL_URL="https://storage.googleapis.com/gemma-models/gemma-3n.tflite"


### PR DESCRIPTION
## Summary
- document one-command installer in README
- installer now prints that it fetches latest Stockfish
- setup scripts query GitHub API to download the newest Stockfish release automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce44e7f78832ebfafdb3cc9a3182b